### PR TITLE
Fix minor errors

### DIFF
--- a/gnome-code-of-conduct-procedures.md
+++ b/gnome-code-of-conduct-procedures.md
@@ -200,7 +200,7 @@ After you have talked to the reported person, follow up with the reporter. You c
 If the report was determined to be a Code of Conduct violation, follow up with the reporter to:
 
  * Outline what behavioral modification plan was given to the reported person.
- * Make sure to mention if the reporter was told not to contact the reporter.
+ * Make sure to mention if the reported person was told not to contact the reporter.
  * Thank them for their report.
  * Ask them to make an additional report if any other behavior makes them feel unsafe or unwelcome.
 

--- a/gnome-code-of-conduct.md
+++ b/gnome-code-of-conduct.md
@@ -75,7 +75,7 @@ This Code of Conduct applies to all online GNOME community spaces:
  * Code repositories - git.gnome.org and gitlab.gnome.org
  * Mailing lists - mail.gnome.org
  * Wikis - wiki.gnome.org
- * Chat and forums - irc.gnome.org such as discourse.gnome.org, GNOME Telegram channels, and GNOME groups and channels on Matrix.org (including bridges to GNOME IRC channels)
+ * Chat and forums - irc.gnome.org, discourse.gnome.org, GNOME Telegram channels, and GNOME groups and channels on Matrix.org (including bridges to GNOME IRC channels)
 
 All participants in GNOME online community spaces are subject to the Code of Conduct. This includes GNOME Foundation board members, corporate sponsors, and paid employees. This also includes volunteers, maintainers, leaders, contributors, contribution reviewers, issue reporters, and anyone participating in discussion in GNOME online spaces.
 


### PR DESCRIPTION
The first commit is for what seems to me like a cut&paste error.

The second one, I think the wording is incorrect?  I assume the intention was to tell the reporter if the reporteD was explicitly told not to contact them.